### PR TITLE
fix(caddy_server): move to repo-specific apt key

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,11 @@ To begin development on this collection, you need to have the following dependen
 ## Quick Start
 
 1. Fork the repository and clone it to your local machine
-2. Run `./scripts/setup.sh` to configure a local dev environment (virtualenv) with a commit hook
-3. Make your changes and commit them to a new branch
-4. Run the tests locally with `./scripts/test.sh`. This will run the full test suite that also runs in the CI
-5. Once you're done, push your changes and open a PR
+2. Run `./scripts/setup.sh` to configure a local dev environment (virtualenv) with a commit hook and the required Ansible dependencies.
+3. Activate the virtualenv with `source .venv/bin/activate`
+4. Make your changes and commit them to a new branch
+5. Run the tests locally with `./scripts/test.sh`. This will run the full test suite that also runs in the CI
+6. Once you're done, push your changes and open a PR
 
 
 ## About commit messages and structure

--- a/roles/caddy_server/tasks/install_debian.yml
+++ b/roles/caddy_server/tasks/install_debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Requirements are installed
-  package:
+  ansible.builtin.package:
     name:
       - debian-keyring
       - debian-archive-keyring
@@ -8,12 +8,18 @@
       - "{{ 'python3-requests' if ansible_python_version is version('3', '>=') else 'python-requests' }}"
     update_cache: yes
 
-- name: Caddy repo key is installed
-  apt_key:
+- name: Old apt-key trusted key is absent
+  ansible.builtin.apt_key:
+    id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
+    state: absent
+
+- name: APT Key is stored in keyring
+  ansible.builtin.apt_key:
     url: https://dl.cloudsmith.io/public/caddy/stable/gpg.key
+    keyring: /usr/share/keyrings/caddy-stable-archive-keyring.gpg
 
 - name: Caddy repository is enabled
-  get_url:
+  ansible.builtin.get_url:
     url: https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt
     dest: /etc/apt/sources.list.d/caddy-stable.list
     owner: root
@@ -21,6 +27,6 @@
     mode: "644"
 
 - name: Caddy is installed
-  package:
+  ansible.builtin.package:
     name: caddy
     update_cache: yes

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ set -e pipefail
 
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install 'gitlint>=0.15.0,<0.16.0'
+python3 -m pip install gitlint ansible ansible-test tox
 
 gitlint install-hook
 


### PR DESCRIPTION
See: https://github.com/caddyserver/website/pull/219
Using a central apt keyring with apt-key is deprecated due to security
concerns. Instead, an individual per-repo keyring is preffered.

Caddy (and more specifically cloudsmith) switched to this new
per-repo keyring format recently. This broke new installs completley
and caused errors on existing installs.

This change fixes both by removing the old global key and adding the new
keyring on new and existing installs.